### PR TITLE
Updating to latest jobs-dsl-plugin (v1.57)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile "org.yaml:snakeyaml:1.10"
     compile 'org.codehaus.groovy:groovy-all:2.4.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.48'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.57'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }

--- a/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
@@ -28,5 +28,5 @@ params['JAC_HOST'] = System.getProperty('JAC_HOST') ?: 'aws'
 new FileNameFinder().getFileNames('.', pattern).each { String fileName ->
     println "\nprocessing file: $fileName"
     File file = new File(fileName)
-    DslScriptLoader.runDslEngine(file.text, jm)
+    new DslScriptLoader(jm).runScripts([file.text])
 }

--- a/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
@@ -3,6 +3,7 @@
 package jenkins.automation.rest
 
 import javaposse.jobdsl.dsl.DslScriptLoader
+import javaposse.jobdsl.dsl.ScriptRequest
 
 String pattern = System.getProperty('pattern')
 String baseUrl = System.getProperty('baseUrl')
@@ -28,5 +29,5 @@ params['JAC_HOST'] = System.getProperty('JAC_HOST') ?: 'aws'
 new FileNameFinder().getFileNames('.', pattern).each { String fileName ->
     println "\nprocessing file: $fileName"
     File file = new File(fileName)
-    new DslScriptLoader(jm).runScripts([file.text])
+    new DslScriptLoader(jm).runScripts([new ScriptRequest(file.text)])
 }

--- a/src/test/groovy/my_job_test.groovy
+++ b/src/test/groovy/my_job_test.groovy
@@ -14,7 +14,7 @@ class my_job_test extends Specification {
 
         when:
         ScriptRequest scriptRequest = new ScriptRequest(null, testjob, new File('.').toURI().toURL())
-        DslScriptLoader.runDslEngine(scriptRequest, jm)
+        new DslScriptLoader(jm).runScripts([scriptRequest])
         def result = jm.savedConfigs.collect { [name: it.key, xml: it.value] }
 
 


### PR DESCRIPTION
This commit brings this repository up to date with the latest DSL core plugin. The main changes was to replace the deprecated API, DslScriptLoader.runDslEngine().

I discovered this issue when trying to use your repository on the latest Jenkins and jobs-dsl-plugin. The issue was the "gradlew rest" command would fail trying to push the jobs to Jenkins. 

With this change and a cooresponding change in "jenkins-as-code-starter-project" I am now able to push jobs up to Jenkins using the "gradlew rest" command.